### PR TITLE
Prevent struct formex_id as empty string to search for form with formex_id empty string

### DIFF
--- a/lib/formex/form_collection.ex
+++ b/lib/formex/form_collection.ex
@@ -88,7 +88,7 @@ defmodule Formex.FormCollection do
   def get_subform_by_struct(form_collection, struct) do
     form_collection.forms
     |> Enum.find(fn form_nested ->
-      if struct.id do
+      if struct.id && struct.id !== "" do
         to_string(form_nested.form.struct.id) == to_string(struct.id)
       else
         form_nested.form.struct.formex_id == struct.formex_id


### PR DESCRIPTION
It looks like the id can also be `""`. So when it is, it matched the first form that contained `formex_id = ""`. The bug showed up when having a nested collection inside a collection.