### PR TITLE
Fix collection form inputs_for when items count is bigger than 10

### DIFF
--- a/lib/formex/builder.ex
+++ b/lib/formex/builder.ex
@@ -87,10 +87,8 @@ defmodule Formex.Builder do
 
               subparams =
                 items
-                |> Enum.count
-                |> (&Range.new(0, &1 - 1)).()
-                |> Enum.zip(items)
-                |> Enum.map(fn {key, item} -> {to_string(key), item} end)
+                |> Enum.with_index()
+                |> Enum.map(fn {item, key} -> {to_string(key), item} end)
                 |> Enum.into(%{})
 
               {key, subparams}

--- a/lib/formex/view.ex
+++ b/lib/formex/view.ex
@@ -209,10 +209,8 @@ defmodule Formex.View do
   defp form_to_params_collection(_form, item) do
     new_val =
       item.forms
-      |> Enum.count()
-      |> (&Range.new(0, &1 - 1)).()
-      |> Enum.zip(item.forms)
-      |> Enum.map(fn {key, nested_form} ->
+      |> Enum.with_index()
+      |> Enum.map(fn {nested_form, key} ->
         sub_struct = nested_form.form.new_struct
 
         subparams =

--- a/lib/formex/view.ex
+++ b/lib/formex/view.ex
@@ -190,7 +190,7 @@ defmodule Formex.View do
   end
 
   @spec form_to_params_nested(form :: Form.t(), item :: FormNested.t()) :: Map.t()
-  defp form_to_params_nested(form, item) do
+  defp form_to_params_nested(_form, item) do
     sub_params = form_to_params(item.form)
     sub_struct = item.form.new_struct
 
@@ -206,7 +206,7 @@ defmodule Formex.View do
   end
 
   @spec form_to_params_collection(form :: Form.t(), item :: FormCollection.t()) :: Map.t()
-  defp form_to_params_collection(form, item) do
+  defp form_to_params_collection(_form, item) do
     new_val =
       item.forms
       |> Enum.count()
@@ -227,7 +227,7 @@ defmodule Formex.View do
             |> to_string
           )
 
-        {to_string(key), subparams}
+        {key, subparams}
       end)
       |> Enum.into(%{})
 

--- a/test/formex/view_test.exs
+++ b/test/formex/view_test.exs
@@ -1,5 +1,15 @@
+defmodule Formex.ViewTestTagType do
+  use Formex.Type
+
+  def build_form(form) do
+    form
+    |> add(:name, :text_input)
+  end
+end
+
 defmodule Formex.ViewTestType do
   use Formex.Type
+  alias Formex.TestModel.Tag
 
   def build_form(form) do
     form
@@ -12,6 +22,7 @@ defmodule Formex.ViewTestType do
     )
     |> add(:content, :textarea)
     |> add(:visible, :checkbox, required: false)
+    |> add(:tags, Formex.ViewTestTagType, struct_module: Tag)
     |> add(
       :category_id,
       :select,
@@ -38,7 +49,9 @@ defmodule Formex.ViewTest do
   alias Formex.TestModel.Article
 
   test "render view" do
-    form = create_form(ViewTestType, %Article{})
+    tags = Enum.map(1..14, &%{id: &1, name: "tag-#{&1}", formex_id: &1})
+
+    form = create_form(ViewTestType, %Article{tags: tags})
 
     {:safe, form_html} =
       Formex.View.formex_form_for(form, "", fn f ->
@@ -52,6 +65,10 @@ defmodule Formex.ViewTest do
     assert String.match?(form_html, ~r/PHP/)
     assert String.match?(form_html, ~r/Submit form/)
     assert String.match?(form_html, ~r/btn-success/)
+
+    tags_ordered = Enum.map(tags, & &1.name) |> Enum.join(".+")
+    tags_ordered_regex = ~r/#{tags_ordered}/
+    assert String.match?(form_html, tags_ordered_regex)
 
     {:safe, form_html} =
       Formex.View.formex_form_for(form, "", fn f ->

--- a/test/support/models/tag.ex
+++ b/test/support/models/tag.ex
@@ -9,5 +9,5 @@
 # end
 
 defmodule Formex.TestModel.Tag do
-  defstruct [:id, :name]
+  defstruct [:id, :name, :formex_id]
 end


### PR DESCRIPTION
Due to the way the `params` injected in `phoenix_form`, a collection items count bigger than 10 would result in an unordered form. Here is why:

By making the key of the map a string, the association looked like this:

```elixir
%{
  "0" => ...
  "1" => ...
  "2" => ...
}
``` 

This is fine until the number 10 shows up since the Elixir Map is not ordered (or if it looks ordered it is an implementation details)

```elixir
%{
  "0" => ...
  "1" => ...
  "10" => ...
  "11" => ...
  "2" => ...
}
```

The test case I wrote simply validate that the tags names appear in order in the generated HTML.
I don’t know the implication of not calling `to_string` on the key but the fix works in my app and all tests pass 😄 